### PR TITLE
Warmup caches before counting cycles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,5 @@ OUTPUTS=$(addprefix bin/, $(SOURCES:.s=.out))
 
 all: $(OUTPUTS)
 
-bin/%.out : %.s
-	${CC} -static -march=rv64gcv -O3 driver/driver.c driver/driver.s $< -o $@
+bin/%.out : %.s driver/driver.c driver/driver.s
+	${CC} -static -march=rv64gcv -O3 $^ -o $@

--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ Note: I used 4-wide independent chains and included V0 in the destination list. 
 
 |     | mf8   | mf4   | mf2   | m1    | m2    | m4    | m8     |
 |:----|:------|:------|:------|:------|:------|:------|:-------|
-| e8  | ~1.00 | ~1.01 | ~1.00 | ~1.99 | ~3.97 | ~7.88 | ~15.20 |
-| e16 | nan   | ~1.00 | ~1.00 | ~1.99 | ~3.97 | ~7.89 | ~15.66 |
-| e32 | nan   | nan   | ~1.00 | ~1.99 | ~3.96 | ~7.83 | ~15.65 |
-| e64 | nan   | nan   | nan   | ~1.99 | ~3.97 | ~7.89 | ~15.66 |
+| e8  | ~1.00 | ~1.00 | ~1.00 | ~2.00 | ~3.97 | ~7.90 | ~15.75 |
+| e16 | nan   | ~1.00 | ~1.00 | ~1.99 | ~3.97 | ~7.91 | ~15.72 |
+| e32 | nan   | nan   | ~1.00 | ~1.99 | ~3.97 | ~7.91 | ~15.74 |
+| e64 | nan   | nan   | nan   | ~1.99 | ~3.97 | ~7.91 | ~15.74 |
 
 Observation:
 * More or less linear scaling as LMUL increases
@@ -131,22 +131,14 @@ Observation:
 
 ### vlse_LMUL_x_SEW_throughput
 
-Investigating reciprocal throughput for strided loads.  There is significant variation from run to run here, the two tables represent two runs immediately back to back.
+Investigating reciprocal throughput for strided loads.
 
-|     | mf8   | mf4   | mf2    | m1     | m2     | m4     | m8      |
-|:----|:------|:------|:-------|:-------|:-------|:-------|:--------|
-| e8  | ~3.91 | ~7.86 | ~14.11 | ~30.70 | ~59.59 | ~86.76 | ~200.06 |
-| e16 | nan   | ~3.96 | ~7.87  | ~15.14 | ~30.69 | ~59.62 | ~89.30  |
-| e32 | nan   | nan   | ~3.96  | ~7.87  | ~15.58 | ~30.73 | ~59.54  |
-| e64 | nan   | nan   | nan    | ~3.96  | ~7.83  | ~15.44 | ~30.45  |
-
-
-|     | mf8   | mf4   | mf2    | m1     | m2     | m4     | m8      |
-|:----|:------|:------|:-------|:-------|:-------|:-------|:--------|
-| e8  | ~3.96 | ~7.87 | ~14.79 | ~30.48 | ~59.32 | ~91.86 | ~202.49 |
-| e16 | nan   | ~3.96 | ~7.86  | ~15.55 | ~28.97 | ~58.53 | ~83.55  |
-| e32 | nan   | nan   | ~3.90  | ~7.78  | ~15.55 | ~27.61 | ~59.63  |
-| e64 | nan   | nan   | nan    | ~3.95  | ~7.87  | ~14.11 | ~30.38  |
+|     | mf8   | mf4   | mf2    | m1     | m2     | m4      | m8      |
+|:----|:------|:------|:-------|:-------|:-------|:--------|:--------|
+| e8  | ~3.97 | ~7.89 | ~15.70 | ~30.83 | ~59.95 | ~116.91 | ~217.52 |
+| e16 | nan   | ~3.96 | ~7.87  | ~15.65 | ~31.06 | ~60.78  | ~115.26 |
+| e32 | nan   | nan   | ~3.96  | ~7.89  | ~15.69 | ~31.06  | ~60.81  |
+| e64 | nan   | nan   | nan    | ~3.96  | ~7.89  | ~15.65  | ~30.99  |
 
 Observations:
 
@@ -156,19 +148,19 @@ Observations:
 
 Here's two runs with a constant stride of 160 bytes.  This should be long enough that each access lands in it's own cache line (for most reasonable cache structures).
 
-|     | mf8   | mf4   | mf2    | m1     | m2     | m4      | m8      |
-|:----|:------|:------|:-------|:-------|:-------|:--------|:--------|
-| e8  | ~3.96 | ~7.47 | ~14.54 | ~27.23 | ~39.34 | ~518.41 | ~501.33 |
-| e16 | nan   | ~3.95 | ~7.31  | ~15.28 | ~28.51 | ~58.56  | ~413.34 |
-| e32 | nan   | nan   | ~3.93  | ~7.87  | ~15.60 | ~30.03  | ~50.31  |
-| e64 | nan   | nan   | nan    | ~3.96  | ~7.79  | ~12.49  | ~27.62  |
+|     | mf8   | mf4   | mf2    | m1     | m2     | m4      | m8       |
+|:----|:------|:------|:-------|:-------|:-------|:--------|:---------|
+| e8  | ~3.96 | ~7.89 | ~15.70 | ~31.03 | ~60.90 | ~653.86 | ~1204.30 |
+| e16 | nan   | ~3.96 | ~7.90  | ~15.65 | ~31.03 | ~60.03  | ~668.94  |
+| e32 | nan   | nan   | ~3.96  | ~7.89  | ~15.70 | ~30.82  | ~60.91   |
+| e64 | nan   | nan   | nan    | ~3.96  | ~7.89  | ~15.70  | ~31.02   |
 
-|     | mf8   | mf4   | mf2    | m1     | m2     | m4      | m8      |
-|:----|:------|:------|:-------|:-------|:-------|:--------|:--------|
-| e8  | ~3.96 | ~7.87 | ~14.72 | ~30.68 | ~59.62 | ~261.31 | ~864.76 |
-| e16 | nan   | ~3.89 | ~7.47  | ~15.62 | ~27.12 | ~49.02  | ~458.83 |
-| e32 | nan   | nan   | ~3.96  | ~7.84  | ~13.79 | ~28.94  | ~51.91  |
-| e64 | nan   | nan   | nan    | ~3.96  | ~7.83  | ~15.61  | ~27.41  |
+|     | mf8   | mf4   | mf2    | m1     | m2     | m4      | m8       |
+|:----|:------|:------|:-------|:-------|:-------|:--------|:---------|
+| e8  | ~3.96 | ~7.90 | ~15.64 | ~30.58 | ~60.85 | ~631.87 | ~1168.03 |
+| e16 | nan   | ~3.97 | ~7.90  | ~15.65 | ~31.05 | ~59.94  | ~732.29  |
+| e32 | nan   | nan   | ~3.96  | ~7.89  | ~15.70 | ~31.04  | ~60.64   |
+| e64 | nan   | nan   | nan    | ~3.97  | ~7.89  | ~15.69  | ~30.84   |
 
 This result seems roughly consistent with a memory system which can issue one 128 bit load per cycle, and is issuing one load per element.  Though I do not understand the high variance, in particular the fact that sometimes the result seems to take less than one cycle per element (when each element should it's own load).
 
@@ -179,52 +171,52 @@ How does vlseg NF vary with NF, LMUL, and SEW?  From above, we strongly suspect 
 
 | NF2 | mf8   | mf4   | mf2   | m1     | m2     | m4     |   m8 |
 |:----|:------|:------|:------|:-------|:-------|:-------|-----:|
-| e8  | ~4.93 | ~4.84 | ~5.93 | ~11.77 | ~20.92 | ~38.02 |  nan |
-| e16 | nan   | ~4.95 | ~5.93 | ~11.79 | ~23.13 | ~44.81 |  nan |
-| e32 | nan   | nan   | ~5.93 | ~11.77 | ~21.11 | ~45.58 |  nan |
-| e64 | nan   | nan   | nan   | ~11.77 | ~20.05 | ~39.23 |  nan |
+| e8  | ~4.95 | ~4.95 | ~5.94 | ~11.79 | ~23.28 | ~45.76 |  nan |
+| e16 | nan   | ~4.95 | ~5.94 | ~11.82 | ~23.37 | ~46.16 |  nan |
+| e32 | nan   | nan   | ~5.94 | ~11.81 | ~23.24 | ~45.92 |  nan |
+| e64 | nan   | nan   | nan   | ~11.83 | ~23.34 | ~46.23 |  nan |
 
 | NF3 | mf8   | mf4   | mf2   | m1     | m2     |   m4 |   m8 |
 |:----|:------|:------|:------|:-------|:-------|-----:|-----:|
-| e8  | ~6.82 | ~7.89 | ~9.82 | ~19.04 | ~31.95 |  nan |  nan |
-| e16 | nan   | ~7.89 | ~9.82 | ~18.75 | ~36.14 |  nan |  nan |
-| e32 | nan   | nan   | ~9.82 | ~18.86 | ~36.38 |  nan |  nan |
-| e64 | nan   | nan   | nan   | ~17.58 | ~34.57 |  nan |  nan |
+| e8  | ~6.93 | ~7.90 | ~9.86 | ~19.59 | ~38.71 |  nan |  nan |
+| e16 | nan   | ~7.90 | ~9.87 | ~19.59 | ~38.09 |  nan |  nan |
+| e32 | nan   | nan   | ~9.87 | ~19.48 | ~38.69 |  nan |  nan |
+| e64 | nan   | nan   | nan   | ~17.61 | ~34.33 |  nan |  nan |
 
 | NF4 | mf8   | mf4   | mf2    | m1     | m2     |   m4 |   m8 |
 |:----|:------|:------|:-------|:-------|:-------|-----:|-----:|
-| e8  | ~8.87 | ~9.84 | ~11.78 | ~23.27 | ~45.58 |  nan |  nan |
-| e16 | nan   | ~9.82 | ~11.79 | ~23.21 | ~45.44 |  nan |  nan |
-| e32 | nan   | nan   | ~11.75 | ~20.35 | ~45.51 |  nan |  nan |
-| e64 | nan   | nan   | nan    | ~23.25 | ~45.62 |  nan |  nan |
+| e8  | ~8.89 | ~9.88 | ~11.82 | ~23.40 | ~45.78 |  nan |  nan |
+| e16 | nan   | ~9.83 | ~11.81 | ~23.45 | ~45.83 |  nan |  nan |
+| e32 | nan   | nan   | ~11.82 | ~23.48 | ~45.84 |  nan |  nan |
+| e64 | nan   | nan   | nan    | ~23.45 | ~45.89 |  nan |  nan |
 
 | NF5 | mf8    | mf4    | mf2    | m1      |   m2 |   m4 |   m8 |
 |:----|:-------|:-------|:-------|:--------|-----:|-----:|-----:|
-| e8  | ~19.50 | ~38.22 | ~72.89 | ~137.19 |  nan |  nan |  nan |
-| e16 | nan    | ~19.49 | ~38.11 | ~73.68  |  nan |  nan |  nan |
-| e32 | nan    | nan    | ~19.43 | ~38.25  |  nan |  nan |  nan |
-| e64 | nan    | nan    | nan    | ~19.45  |  nan |  nan |  nan |
+| e8  | ~19.61 | ~38.54 | ~75.33 | ~143.13 |  nan |  nan |  nan |
+| e16 | nan    | ~19.62 | ~38.67 | ~74.74  |  nan |  nan |  nan |
+| e32 | nan    | nan    | ~19.61 | ~38.57  |  nan |  nan |  nan |
+| e64 | nan    | nan    | nan    | ~19.56  |  nan |  nan |  nan |
 
 | NF6 | mf8    | mf4    | mf2    | m1      |   m2 |   m4 |   m8 |
 |:----|:-------|:-------|:-------|:--------|-----:|-----:|-----:|
-| e8  | ~23.25 | ~45.50 | ~86.21 | ~160.46 |  nan |  nan |  nan |
-| e16 | nan    | ~23.27 | ~44.49 | ~87.08  |  nan |  nan |  nan |
-| e32 | nan    | nan    | ~23.28 | ~45.54  |  nan |  nan |  nan |
-| e64 | nan    | nan    | nan    | ~23.29  |  nan |  nan |  nan |
+| e8  | ~23.42 | ~45.46 | ~89.43 | ~166.19 |  nan |  nan |  nan |
+| e16 | nan    | ~23.45 | ~45.96 | ~88.50  |  nan |  nan |  nan |
+| e32 | nan    | nan    | ~23.39 | ~46.17  |  nan |  nan |  nan |
+| e64 | nan    | nan    | nan    | ~23.24  |  nan |  nan |  nan |
 
-| NF7 | mf8    | mf4    | mf2    | m1      |   m2 |   m4 |   m8 |
-|:----|:-------|:-------|:-------|:--------|-----:|-----:|-----:|
-| e8  | ~27.06 | ~52.61 | ~74.48 | ~181.47 |  nan |  nan |  nan |
-| e16 | nan    | ~27.06 | ~45.61 | ~100.49 |  nan |  nan |  nan |
-| e32 | nan    | nan    | ~23.64 | ~51.89  |  nan |  nan |  nan |
-| e64 | nan    | nan    | nan    | ~22.87  |  nan |  nan |  nan |
+| NF7 | mf8    | mf4    | mf2     | m1      |   m2 |   m4 |   m8 |
+|:----|:-------|:-------|:--------|:--------|-----:|-----:|-----:|
+| e8  | ~27.20 | ~53.34 | ~102.10 | ~188.91 |  nan |  nan |  nan |
+| e16 | nan    | ~27.24 | ~52.94  | ~101.70 |  nan |  nan |  nan |
+| e32 | nan    | nan    | ~27.16  | ~53.17  |  nan |  nan |  nan |
+| e64 | nan    | nan    | nan     | ~27.26  |  nan |  nan |  nan |
 
 | NF8 | mf8    | mf4    | mf2     | m1      |   m2 |   m4 |   m8 |
 |:----|:-------|:-------|:--------|:--------|-----:|-----:|-----:|
-| e8  | ~30.82 | ~59.74 | ~108.35 | ~201.51 |  nan |  nan |  nan |
-| e16 | nan    | ~29.02 | ~54.41  | ~86.09  |  nan |  nan |  nan |
-| e32 | nan    | nan    | ~26.47  | ~57.84  |  nan |  nan |  nan |
-| e64 | nan    | nan    | nan     | ~30.09  |  nan |  nan |  nan |
+| e8  | ~30.97 | ~60.45 | ~114.86 | ~207.97 |  nan |  nan |  nan |
+| e16 | nan    | ~31.00 | ~60.67  | ~115.57 |  nan |  nan |  nan |
+| e32 | nan    | nan    | ~30.98  | ~60.48  |  nan |  nan |  nan |
+| e64 | nan    | nan    | nan     | ~31.01  |  nan |  nan |  nan |
 
 Observation:
 * It looks like there's some kind of change between NF2-4 and NF5-8.  The later appear to scale roughly with VLMAX (i.e. the distinct number of segments).  The NF2, NF3, and NF4 cases are clearly different.  I'm guessing these are done as a single wide load followed by a couple of special shuffles.

--- a/campaigns/vle_LMUL_x_SEW_throughput/raw2.out
+++ b/campaigns/vle_LMUL_x_SEW_throughput/raw2.out
@@ -1,0 +1,160 @@
+Running vle-e16_m1_vlmax.out
+-9223372036851960293 cycles, -9223372036853604646 instret (before)
+-9223372036811707462 cycles, -9223372036833438372 instret (after)
+40252831 cycles, 20166274 instret elapsed
+  ~1.996047 cycles-per-inst
+  ~2012.641550 cycles-per-iteration
+  ~1008.313700 insts-per-iteration
+Running vle-e16_m2_vlmax.out
+-9223372036852055012 cycles, -9223372036853666659 instret (before)
+-9223372036771808129 cycles, -9223372036833472018 instret (after)
+80246883 cycles, 20194641 instret elapsed
+  ~3.973672 cycles-per-inst
+  ~4012.344150 cycles-per-iteration
+  ~1009.732050 insts-per-iteration
+Running vle-e16_m4_vlmax.out
+-9223372036851981815 cycles, -9223372036853603574 instret (before)
+-9223372036691701557 cycles, -9223372036833354342 instret (after)
+160280258 cycles, 20249232 instret elapsed
+  ~7.915375 cycles-per-inst
+  ~8014.012900 cycles-per-iteration
+  ~1012.461600 insts-per-iteration
+Running vle-e16_m8_vlmax.out
+-9223372036851973750 cycles, -9223372036853604729 instret (before)
+-9223372036531352232 cycles, -9223372036833216324 instret (after)
+320621518 cycles, 20388405 instret elapsed
+  ~15.725679 cycles-per-inst
+  ~16031.075900 cycles-per-iteration
+  ~1019.420250 insts-per-iteration
+Running vle-e16_mf2_vlmax.out
+-9223372036851968387 cycles, -9223372036853604762 instret (before)
+-9223372036831668372 cycles, -9223372036833437195 instret (after)
+20300015 cycles, 20167567 instret elapsed
+  ~1.006567 cycles-per-inst
+  ~1015.000750 cycles-per-iteration
+  ~1008.378350 insts-per-iteration
+Running vle-e16_mf4_vlmax.out
+-9223372036852093814 cycles, -9223372036853674750 instret (before)
+-9223372036831852469 cycles, -9223372036833522886 instret (after)
+20241345 cycles, 20151864 instret elapsed
+  ~1.004440 cycles-per-inst
+  ~1012.067250 cycles-per-iteration
+  ~1007.593200 insts-per-iteration
+Running vle-e16_mf8_vlmax.out
+Running vle-e32_m1_vlmax.out
+-9223372036851978379 cycles, -9223372036853610994 instret (before)
+-9223372036811610740 cycles, -9223372036833421967 instret (after)
+40367639 cycles, 20189027 instret elapsed
+  ~1.999484 cycles-per-inst
+  ~2018.381950 cycles-per-iteration
+  ~1009.451350 insts-per-iteration
+Running vle-e32_m2_vlmax.out
+-9223372036852034291 cycles, -9223372036853665322 instret (before)
+-9223372036771787343 cycles, -9223372036833470012 instret (after)
+80246948 cycles, 20195310 instret elapsed
+  ~3.973544 cycles-per-inst
+  ~4012.347400 cycles-per-iteration
+  ~1009.765500 insts-per-iteration
+Running vle-e32_m4_vlmax.out
+-9223372036851965895 cycles, -9223372036853602750 instret (before)
+-9223372036691558479 cycles, -9223372036833333270 instret (after)
+160407416 cycles, 20269480 instret elapsed
+  ~7.913741 cycles-per-inst
+  ~8020.370800 cycles-per-iteration
+  ~1013.474000 insts-per-iteration
+Running vle-e32_m8_vlmax.out
+-9223372036851928143 cycles, -9223372036853611041 instret (before)
+-9223372036531457315 cycles, -9223372036833254634 instret (after)
+320470828 cycles, 20356407 instret elapsed
+  ~15.742996 cycles-per-inst
+  ~16023.541400 cycles-per-iteration
+  ~1017.820350 insts-per-iteration
+Running vle-e32_mf2_vlmax.out
+-9223372036851987877 cycles, -9223372036853599563 instret (before)
+-9223372036831769162 cycles, -9223372036833448755 instret (after)
+20218715 cycles, 20150808 instret elapsed
+  ~1.003370 cycles-per-inst
+  ~1010.935750 cycles-per-iteration
+  ~1007.540400 insts-per-iteration
+Running vle-e32_mf4_vlmax.out
+Running vle-e32_mf8_vlmax.out
+Running vle-e64_m1_vlmax.out
+-9223372036851899621 cycles, -9223372036853644106 instret (before)
+-9223372036811635456 cycles, -9223372036833469704 instret (after)
+40264165 cycles, 20174402 instret elapsed
+  ~1.995805 cycles-per-inst
+  ~2013.208250 cycles-per-iteration
+  ~1008.720100 insts-per-iteration
+Running vle-e64_m2_vlmax.out
+-9223372036851963802 cycles, -9223372036853576607 instret (before)
+-9223372036771498136 cycles, -9223372036833338772 instret (after)
+80465666 cycles, 20237835 instret elapsed
+  ~3.976002 cycles-per-inst
+  ~4023.283300 cycles-per-iteration
+  ~1011.891750 insts-per-iteration
+Running vle-e64_m4_vlmax.out
+-9223372036852002435 cycles, -9223372036853605760 instret (before)
+-9223372036691654015 cycles, -9223372036833351593 instret (after)
+160348420 cycles, 20254167 instret elapsed
+  ~7.916811 cycles-per-inst
+  ~8017.421000 cycles-per-iteration
+  ~1012.708350 insts-per-iteration
+Running vle-e64_m8_vlmax.out
+-9223372036851867135 cycles, -9223372036853602264 instret (before)
+-9223372036531421387 cycles, -9223372036833248868 instret (after)
+320445748 cycles, 20353396 instret elapsed
+  ~15.744092 cycles-per-inst
+  ~16022.287400 cycles-per-iteration
+  ~1017.669800 insts-per-iteration
+Running vle-e64_mf2_vlmax.out
+Running vle-e64_mf4_vlmax.out
+Running vle-e64_mf8_vlmax.out
+Running vle-e8_m1_vlmax.out
+-9223372036851805609 cycles, -9223372036853583504 instret (before)
+-9223372036811399449 cycles, -9223372036833387109 instret (after)
+40406160 cycles, 20196395 instret elapsed
+  ~2.000662 cycles-per-inst
+  ~2020.308000 cycles-per-iteration
+  ~1009.819750 insts-per-iteration
+Running vle-e8_m2_vlmax.out
+-9223372036852076795 cycles, -9223372036853673090 instret (before)
+-9223372036771817352 cycles, -9223372036833473978 instret (after)
+80259443 cycles, 20199112 instret elapsed
+  ~3.973414 cycles-per-inst
+  ~4012.972150 cycles-per-iteration
+  ~1009.955600 insts-per-iteration
+Running vle-e8_m4_vlmax.out
+-9223372036851911252 cycles, -9223372036853576637 instret (before)
+-9223372036691385877 cycles, -9223372036833257757 instret (after)
+160525375 cycles, 20318880 instret elapsed
+  ~7.900306 cycles-per-inst
+  ~8026.268750 cycles-per-iteration
+  ~1015.944000 insts-per-iteration
+Running vle-e8_m8_vlmax.out
+-9223372036851972079 cycles, -9223372036853602175 instret (before)
+-9223372036531315488 cycles, -9223372036833244875 instret (after)
+320656591 cycles, 20357300 instret elapsed
+  ~15.751430 cycles-per-inst
+  ~16032.829550 cycles-per-iteration
+  ~1017.865000 insts-per-iteration
+Running vle-e8_mf2_vlmax.out
+-9223372036851958587 cycles, -9223372036853605500 instret (before)
+-9223372036831702864 cycles, -9223372036833451888 instret (after)
+20255723 cycles, 20153612 instret elapsed
+  ~1.005067 cycles-per-inst
+  ~1012.786150 cycles-per-iteration
+  ~1007.680600 insts-per-iteration
+Running vle-e8_mf4_vlmax.out
+-9223372036851952266 cycles, -9223372036853599259 instret (before)
+-9223372036831727354 cycles, -9223372036833448809 instret (after)
+20224912 cycles, 20150450 instret elapsed
+  ~1.003695 cycles-per-inst
+  ~1011.245600 cycles-per-iteration
+  ~1007.522500 insts-per-iteration
+Running vle-e8_mf8_vlmax.out
+-9223372036852107806 cycles, -9223372036853668767 instret (before)
+-9223372036831870760 cycles, -9223372036833517056 instret (after)
+20237046 cycles, 20151711 instret elapsed
+  ~1.004235 cycles-per-inst
+  ~1011.852300 cycles-per-iteration
+  ~1007.585550 insts-per-iteration

--- a/campaigns/vlse_LMUL_x_SEW_throughput/raw3.out
+++ b/campaigns/vlse_LMUL_x_SEW_throughput/raw3.out
@@ -1,0 +1,160 @@
+Running vlse-e16_m1_vlmax.out
+-9223372036851975548 cycles, -9223372036853581083 instret (before)
+-9223372036595337232 cycles, -9223372036837183408 instret (after)
+256638316 cycles, 16397675 instret elapsed
+  ~15.650897 cycles-per-inst
+  ~12831.915800 cycles-per-iteration
+  ~819.883750 insts-per-iteration
+Running vlse-e16_m2_vlmax.out
+-9223372036851897141 cycles, -9223372036853602888 instret (before)
+-9223372036339158152 cycles, -9223372036837096540 instret (after)
+512738989 cycles, 16506348 instret elapsed
+  ~31.063139 cycles-per-inst
+  ~25636.949450 cycles-per-iteration
+  ~825.317400 insts-per-iteration
+Running vlse-e16_m4_vlmax.out
+-9223372036851947342 cycles, -9223372036853616645 instret (before)
+-9223372035826466360 cycles, -9223372036836745910 instret (after)
+1025480982 cycles, 16870735 instret elapsed
+  ~60.784606 cycles-per-inst
+  ~51274.049100 cycles-per-iteration
+  ~843.536750 insts-per-iteration
+Running vlse-e16_m8_vlmax.out
+-9223372036851987300 cycles, -9223372036853678849 instret (before)
+-9223372034801050375 cycles, -9223372036835886252 instret (after)
+2050936925 cycles, 17792597 instret elapsed
+  ~115.269116 cycles-per-inst
+  ~102546.846250 cycles-per-iteration
+  ~889.629850 insts-per-iteration
+Running vlse-e16_mf2_vlmax.out
+-9223372036852017381 cycles, -9223372036853586342 instret (before)
+-9223372036723411100 cycles, -9223372036837255924 instret (after)
+128606281 cycles, 16330418 instret elapsed
+  ~7.875260 cycles-per-inst
+  ~6430.314050 cycles-per-iteration
+  ~816.520900 insts-per-iteration
+Running vlse-e16_mf4_vlmax.out
+-9223372036851991915 cycles, -9223372036853611452 instret (before)
+-9223372036787615896 cycles, -9223372036837388888 instret (after)
+64376019 cycles, 16222564 instret elapsed
+  ~3.968301 cycles-per-inst
+  ~3218.800950 cycles-per-iteration
+  ~811.128200 insts-per-iteration
+Running vlse-e16_mf8_vlmax.out
+Running vlse-e32_m1_vlmax.out
+-9223372036851814454 cycles, -9223372036853563609 instret (before)
+-9223372036723418226 cycles, -9223372036837297840 instret (after)
+128396228 cycles, 16265769 instret elapsed
+  ~7.893646 cycles-per-inst
+  ~6419.811400 cycles-per-iteration
+  ~813.288450 insts-per-iteration
+Running vlse-e32_m2_vlmax.out
+-9223372036851973258 cycles, -9223372036853616073 instret (before)
+-9223372036595353463 cycles, -9223372036837264267 instret (after)
+256619795 cycles, 16351806 instret elapsed
+  ~15.693667 cycles-per-inst
+  ~12830.989750 cycles-per-iteration
+  ~817.590300 insts-per-iteration
+Running vlse-e32_m4_vlmax.out
+-9223372036851958972 cycles, -9223372036853608059 instret (before)
+-9223372036339242889 cycles, -9223372036837101263 instret (after)
+512716083 cycles, 16506796 instret elapsed
+  ~31.060909 cycles-per-inst
+  ~25635.804150 cycles-per-iteration
+  ~825.339800 insts-per-iteration
+Running vlse-e32_m8_vlmax.out
+-9223372036851957512 cycles, -9223372036853619425 instret (before)
+-9223372035826257403 cycles, -9223372036836753330 instret (after)
+1025700109 cycles, 16866095 instret elapsed
+  ~60.814321 cycles-per-inst
+  ~51285.005450 cycles-per-iteration
+  ~843.304750 insts-per-iteration
+Running vlse-e32_mf2_vlmax.out
+-9223372036851948863 cycles, -9223372036853608154 instret (before)
+-9223372036787664573 cycles, -9223372036837403969 instret (after)
+64284290 cycles, 16204185 instret elapsed
+  ~3.967141 cycles-per-inst
+  ~3214.214500 cycles-per-iteration
+  ~810.209250 insts-per-iteration
+Running vlse-e32_mf4_vlmax.out
+Running vlse-e32_mf8_vlmax.out
+Running vlse-e64_m1_vlmax.out
+-9223372036851972703 cycles, -9223372036853586668 instret (before)
+-9223372036787641168 cycles, -9223372036837373342 instret (after)
+64331535 cycles, 16213326 instret elapsed
+  ~3.967819 cycles-per-inst
+  ~3216.576750 cycles-per-iteration
+  ~810.666300 insts-per-iteration
+Running vlse-e64_m2_vlmax.out
+-9223372036851975268 cycles, -9223372036853609796 instret (before)
+-9223372036723525082 cycles, -9223372036837339283 instret (after)
+128450186 cycles, 16270513 instret elapsed
+  ~7.894661 cycles-per-inst
+  ~6422.509300 cycles-per-iteration
+  ~813.525650 insts-per-iteration
+Running vlse-e64_m4_vlmax.out
+-9223372036852106316 cycles, -9223372036853679620 instret (before)
+-9223372036595353141 cycles, -9223372036837275666 instret (after)
+256753175 cycles, 16403954 instret elapsed
+  ~15.651908 cycles-per-inst
+  ~12837.658750 cycles-per-iteration
+  ~820.197700 insts-per-iteration
+Running vlse-e64_m8_vlmax.out
+-9223372036851899194 cycles, -9223372036853602397 instret (before)
+-9223372036338961878 cycles, -9223372036837051722 instret (after)
+512937316 cycles, 16550675 instret elapsed
+  ~30.991927 cycles-per-inst
+  ~25646.865800 cycles-per-iteration
+  ~827.533750 insts-per-iteration
+Running vlse-e64_mf2_vlmax.out
+Running vlse-e64_mf4_vlmax.out
+Running vlse-e64_mf8_vlmax.out
+Running vlse-e8_m1_vlmax.out
+-9223372036851896202 cycles, -9223372036853578066 instret (before)
+-9223372036338548841 cycles, -9223372036836931734 instret (after)
+513347361 cycles, 16646332 instret elapsed
+  ~30.838467 cycles-per-inst
+  ~25667.368050 cycles-per-iteration
+  ~832.316600 insts-per-iteration
+Running vlse-e8_m2_vlmax.out
+-9223372036852056010 cycles, -9223372036853674758 instret (before)
+-9223372035826075218 cycles, -9223372036836562800 instret (after)
+1025980792 cycles, 17111958 instret elapsed
+  ~59.956949 cycles-per-inst
+  ~51299.039600 cycles-per-iteration
+  ~855.597900 insts-per-iteration
+Running vlse-e8_m4_vlmax.out
+-9223372036851760162 cycles, -9223372036853590720 instret (before)
+-9223372034801419928 cycles, -9223372036836053969 instret (after)
+2050340234 cycles, 17536751 instret elapsed
+  ~116.916767 cycles-per-inst
+  ~102517.011700 cycles-per-iteration
+  ~876.837550 insts-per-iteration
+Running vlse-e8_m8_vlmax.out
+-9223372036851688326 cycles, -9223372036853611500 instret (before)
+-9223372032750487461 cycles, -9223372036834757252 instret (after)
+4101200865 cycles, 18854248 instret elapsed
+  ~217.521317 cycles-per-inst
+  ~205060.043250 cycles-per-iteration
+  ~942.712400 insts-per-iteration
+Running vlse-e8_mf2_vlmax.out
+-9223372036852020648 cycles, -9223372036853618980 instret (before)
+-9223372036595508821 cycles, -9223372036837284938 instret (after)
+256511827 cycles, 16334042 instret elapsed
+  ~15.704124 cycles-per-inst
+  ~12825.591350 cycles-per-iteration
+  ~816.702100 insts-per-iteration
+Running vlse-e8_mf4_vlmax.out
+-9223372036851919492 cycles, -9223372036853611965 instret (before)
+-9223372036723436119 cycles, -9223372036837340115 instret (after)
+128483373 cycles, 16271850 instret elapsed
+  ~7.896052 cycles-per-inst
+  ~6424.168650 cycles-per-iteration
+  ~813.592500 insts-per-iteration
+Running vlse-e8_mf8_vlmax.out
+-9223372036851944514 cycles, -9223372036853588529 instret (before)
+-9223372036787422264 cycles, -9223372036837348404 instret (after)
+64522250 cycles, 16240125 instret elapsed
+  ~3.973014 cycles-per-inst
+  ~3226.112500 cycles-per-iteration
+  ~812.006250 insts-per-iteration

--- a/campaigns/vlse_LMUL_x_SEW_throughput/raw4.out
+++ b/campaigns/vlse_LMUL_x_SEW_throughput/raw4.out
@@ -1,0 +1,160 @@
+Running vlse-e16_m1_vlmax.out
+-9223372036853655233 cycles, -9223372036854428651 instret (before)
+-9223372036597166657 cycles, -9223372036838095825 instret (after)
+256488576 cycles, 16332826 instret elapsed
+  ~15.703870 cycles-per-inst
+  ~12824.428800 cycles-per-iteration
+  ~816.641300 insts-per-iteration
+Running vlse-e16_m2_vlmax.out
+-9223372036853669846 cycles, -9223372036854428678 instret (before)
+-9223372036340879764 cycles, -9223372036837920196 instret (after)
+512790082 cycles, 16508482 instret elapsed
+  ~31.062219 cycles-per-inst
+  ~25639.504100 cycles-per-iteration
+  ~825.424100 insts-per-iteration
+Running vlse-e16_m4_vlmax.out
+-9223372036853607008 cycles, -9223372036854428078 instret (before)
+-9223372035828291304 cycles, -9223372036837574941 instret (after)
+1025315704 cycles, 16853137 instret elapsed
+  ~60.838270 cycles-per-inst
+  ~51265.785200 cycles-per-iteration
+  ~842.656850 insts-per-iteration
+Running vlse-e16_m8_vlmax.out
+-9223372036853561530 cycles, -9223372036854428318 instret (before)
+-9223372034803199702 cycles, -9223372036836894194 instret (after)
+2050361828 cycles, 17534124 instret elapsed
+  ~116.935515 cycles-per-inst
+  ~102518.091400 cycles-per-iteration
+  ~876.706200 insts-per-iteration
+Running vlse-e16_mf2_vlmax.out
+-9223372036853652986 cycles, -9223372036854427588 instret (before)
+-9223372036725272714 cycles, -9223372036838177899 instret (after)
+128380272 cycles, 16249689 instret elapsed
+  ~7.900476 cycles-per-inst
+  ~6419.013600 cycles-per-iteration
+  ~812.484450 insts-per-iteration
+Running vlse-e16_mf4_vlmax.out
+-9223372036853610425 cycles, -9223372036854422686 instret (before)
+-9223372036789214719 cycles, -9223372036838193183 instret (after)
+64395706 cycles, 16229503 instret elapsed
+  ~3.967817 cycles-per-inst
+  ~3219.785300 cycles-per-iteration
+  ~811.475150 insts-per-iteration
+Running vlse-e16_mf8_vlmax.out
+Running vlse-e32_m1_vlmax.out
+-9223372036853675264 cycles, -9223372036854428520 instret (before)
+-9223372036725168902 cycles, -9223372036838146133 instret (after)
+128506362 cycles, 16282387 instret elapsed
+  ~7.892354 cycles-per-inst
+  ~6425.318100 cycles-per-iteration
+  ~814.119350 insts-per-iteration
+Running vlse-e32_m2_vlmax.out
+-9223372036853641844 cycles, -9223372036854427751 instret (before)
+-9223372036596898652 cycles, -9223372036838052241 instret (after)
+256743192 cycles, 16375510 instret elapsed
+  ~15.678485 cycles-per-inst
+  ~12837.159600 cycles-per-iteration
+  ~818.775500 insts-per-iteration
+Running vlse-e32_m4_vlmax.out
+-9223372036853580689 cycles, -9223372036854421823 instret (before)
+-9223372036340734712 cycles, -9223372036837900820 instret (after)
+512845977 cycles, 16521003 instret elapsed
+  ~31.042061 cycles-per-inst
+  ~25642.298850 cycles-per-iteration
+  ~826.050150 insts-per-iteration
+Running vlse-e32_m8_vlmax.out
+-9223372036853657214 cycles, -9223372036854429253 instret (before)
+-9223372035828324519 cycles, -9223372036837580737 instret (after)
+1025332695 cycles, 16848516 instret elapsed
+  ~60.855965 cycles-per-inst
+  ~51266.634750 cycles-per-iteration
+  ~842.425800 insts-per-iteration
+Running vlse-e32_mf2_vlmax.out
+-9223372036853676002 cycles, -9223372036854428697 instret (before)
+-9223372036789367533 cycles, -9223372036838222676 instret (after)
+64308469 cycles, 16206021 instret elapsed
+  ~3.968184 cycles-per-inst
+  ~3215.423450 cycles-per-iteration
+  ~810.301050 insts-per-iteration
+Running vlse-e32_mf4_vlmax.out
+Running vlse-e32_mf8_vlmax.out
+Running vlse-e64_m1_vlmax.out
+-9223372036853667108 cycles, -9223372036854428554 instret (before)
+-9223372036788953897 cycles, -9223372036838157149 instret (after)
+64713211 cycles, 16271405 instret elapsed
+  ~3.977113 cycles-per-inst
+  ~3235.660550 cycles-per-iteration
+  ~813.570250 insts-per-iteration
+Running vlse-e64_m2_vlmax.out
+-9223372036853713351 cycles, -9223372036854428957 instret (before)
+-9223372036725138940 cycles, -9223372036838146338 instret (after)
+128574411 cycles, 16282619 instret elapsed
+  ~7.896421 cycles-per-inst
+  ~6428.720550 cycles-per-iteration
+  ~814.130950 insts-per-iteration
+Running vlse-e64_m4_vlmax.out
+-9223372036853678562 cycles, -9223372036854428665 instret (before)
+-9223372036597144320 cycles, -9223372036838091087 instret (after)
+256534242 cycles, 16337578 instret elapsed
+  ~15.702097 cycles-per-inst
+  ~12826.712100 cycles-per-iteration
+  ~816.878900 insts-per-iteration
+Running vlse-e64_m8_vlmax.out
+-9223372036853638100 cycles, -9223372036854429271 instret (before)
+-9223372036340811097 cycles, -9223372036837908659 instret (after)
+512827003 cycles, 16520612 instret elapsed
+  ~31.041647 cycles-per-inst
+  ~25641.350150 cycles-per-iteration
+  ~826.030600 insts-per-iteration
+Running vlse-e64_mf2_vlmax.out
+Running vlse-e64_mf4_vlmax.out
+Running vlse-e64_mf8_vlmax.out
+Running vlse-e8_m1_vlmax.out
+-9223372036853409114 cycles, -9223372036854384824 instret (before)
+-9223372036340447075 cycles, -9223372036837825154 instret (after)
+512962039 cycles, 16559670 instret elapsed
+  ~30.976586 cycles-per-inst
+  ~25648.101950 cycles-per-iteration
+  ~827.983500 insts-per-iteration
+Running vlse-e8_m2_vlmax.out
+-9223372036853614610 cycles, -9223372036854428771 instret (before)
+-9223372035827109074 cycles, -9223372036837173155 instret (after)
+1026505536 cycles, 17255616 instret elapsed
+  ~59.488200 cycles-per-inst
+  ~51325.276800 cycles-per-iteration
+  ~862.780800 insts-per-iteration
+Running vlse-e8_m4_vlmax.out
+-9223372036853552628 cycles, -9223372036854420366 instret (before)
+-9223372034803323133 cycles, -9223372036836920231 instret (after)
+2050229495 cycles, 17500135 instret elapsed
+  ~117.155067 cycles-per-inst
+  ~102511.474750 cycles-per-iteration
+  ~875.006750 insts-per-iteration
+Running vlse-e8_m8_vlmax.out
+-9223372036853425614 cycles, -9223372036854424031 instret (before)
+-9223372032751755037 cycles, -9223372036835015994 instret (after)
+4101670577 cycles, 19408037 instret elapsed
+  ~211.338765 cycles-per-inst
+  ~205083.528850 cycles-per-iteration
+  ~970.401850 insts-per-iteration
+Running vlse-e8_mf2_vlmax.out
+-9223372036853619762 cycles, -9223372036854420385 instret (before)
+-9223372036597146030 cycles, -9223372036838086628 instret (after)
+256473732 cycles, 16333757 instret elapsed
+  ~15.702066 cycles-per-inst
+  ~12823.686600 cycles-per-iteration
+  ~816.687850 insts-per-iteration
+Running vlse-e8_mf4_vlmax.out
+-9223372036853653866 cycles, -9223372036854428932 instret (before)
+-9223372036725248769 cycles, -9223372036838178985 instret (after)
+128405097 cycles, 16249947 instret elapsed
+  ~7.901878 cycles-per-inst
+  ~6420.254850 cycles-per-iteration
+  ~812.497350 insts-per-iteration
+Running vlse-e8_mf8_vlmax.out
+-9223372036853689258 cycles, -9223372036854428341 instret (before)
+-9223372036789379095 cycles, -9223372036838224376 instret (after)
+64310163 cycles, 16203965 instret elapsed
+  ~3.968792 cycles-per-inst
+  ~3215.508150 cycles-per-iteration
+  ~810.198250 insts-per-iteration

--- a/campaigns/vlse_LMUL_x_SEW_throughput_stride160/raw3.out
+++ b/campaigns/vlse_LMUL_x_SEW_throughput_stride160/raw3.out
@@ -1,0 +1,160 @@
+Running vlse-e16_m1_vlmax.out
+-9223372036853670253 cycles, -9223372036854426409 instret (before)
+-9223372036597208833 cycles, -9223372036838095863 instret (after)
+256461420 cycles, 16330546 instret elapsed
+  ~15.704400 cycles-per-inst
+  ~12823.071000 cycles-per-iteration
+  ~816.527300 insts-per-iteration
+Running vlse-e16_m2_vlmax.out
+-9223372036853644935 cycles, -9223372036854425280 instret (before)
+-9223372036340794821 cycles, -9223372036837905719 instret (after)
+512850114 cycles, 16519561 instret elapsed
+  ~31.045021 cycles-per-inst
+  ~25642.505700 cycles-per-iteration
+  ~825.978050 insts-per-iteration
+Running vlse-e16_m4_vlmax.out
+-9223372036853626848 cycles, -9223372036854426089 instret (before)
+-9223372035828309738 cycles, -9223372036837565971 instret (after)
+1025317110 cycles, 16860118 instret elapsed
+  ~60.813163 cycles-per-inst
+  ~51265.855500 cycles-per-iteration
+  ~843.005900 insts-per-iteration
+Running vlse-e16_m8_vlmax.out
+-9223372036850745648 cycles, -9223372036854401779 instret (before)
+-9223372018200488544 cycles, -9223372036823475510 instret (after)
+18650257104 cycles, 30926269 instret elapsed
+  ~603.055516 cycles-per-inst
+  ~932512.855200 cycles-per-iteration
+  ~1546.313450 insts-per-iteration
+Running vlse-e16_mf2_vlmax.out
+-9223372036853677967 cycles, -9223372036854428742 instret (before)
+-9223372036725310770 cycles, -9223372036838180180 instret (after)
+128367197 cycles, 16248562 instret elapsed
+  ~7.900219 cycles-per-inst
+  ~6418.359850 cycles-per-iteration
+  ~812.428100 insts-per-iteration
+Running vlse-e16_mf4_vlmax.out
+-9223372036853695860 cycles, -9223372036854427799 instret (before)
+-9223372036789138651 cycles, -9223372036838197273 instret (after)
+64557209 cycles, 16230526 instret elapsed
+  ~3.977518 cycles-per-inst
+  ~3227.860450 cycles-per-iteration
+  ~811.526300 insts-per-iteration
+Running vlse-e16_mf8_vlmax.out
+Running vlse-e32_m1_vlmax.out
+-9223372036853701588 cycles, -9223372036854429135 instret (before)
+-9223372036724984828 cycles, -9223372036838101657 instret (after)
+128716760 cycles, 16327478 instret elapsed
+  ~7.883444 cycles-per-inst
+  ~6435.838000 cycles-per-iteration
+  ~816.373900 insts-per-iteration
+Running vlse-e32_m2_vlmax.out
+-9223372036853643930 cycles, -9223372036854429137 instret (before)
+-9223372036596629046 cycles, -9223372036838012339 instret (after)
+257014884 cycles, 16416798 instret elapsed
+  ~15.655604 cycles-per-inst
+  ~12850.744200 cycles-per-iteration
+  ~820.839900 insts-per-iteration
+Running vlse-e32_m4_vlmax.out
+-9223372036853583850 cycles, -9223372036854419789 instret (before)
+-9223372036340783665 cycles, -9223372036837899928 instret (after)
+512800185 cycles, 16519861 instret elapsed
+  ~31.041435 cycles-per-inst
+  ~25640.009250 cycles-per-iteration
+  ~825.993050 insts-per-iteration
+Running vlse-e32_m8_vlmax.out
+-9223372036853585294 cycles, -9223372036854425980 instret (before)
+-9223372035828191241 cycles, -9223372036837577612 instret (after)
+1025394053 cycles, 16848368 instret elapsed
+  ~60.860141 cycles-per-inst
+  ~51269.702650 cycles-per-iteration
+  ~842.418400 insts-per-iteration
+Running vlse-e32_mf2_vlmax.out
+-9223372036853719943 cycles, -9223372036854428031 instret (before)
+-9223372036789283619 cycles, -9223372036838198787 instret (after)
+64436324 cycles, 16229244 instret elapsed
+  ~3.970384 cycles-per-inst
+  ~3221.816200 cycles-per-iteration
+  ~811.462200 insts-per-iteration
+Running vlse-e32_mf4_vlmax.out
+Running vlse-e32_mf8_vlmax.out
+Running vlse-e64_m1_vlmax.out
+-9223372036853652405 cycles, -9223372036854421114 instret (before)
+-9223372036789125437 cycles, -9223372036838160182 instret (after)
+64526968 cycles, 16260932 instret elapsed
+  ~3.968221 cycles-per-inst
+  ~3226.348400 cycles-per-iteration
+  ~813.046600 insts-per-iteration
+Running vlse-e64_m2_vlmax.out
+-9223372036853653784 cycles, -9223372036854428477 instret (before)
+-9223372036725259062 cycles, -9223372036838177194 instret (after)
+128394722 cycles, 16251283 instret elapsed
+  ~7.900590 cycles-per-inst
+  ~6419.736100 cycles-per-iteration
+  ~812.564150 insts-per-iteration
+Running vlse-e64_m4_vlmax.out
+-9223372036853647310 cycles, -9223372036854428583 instret (before)
+-9223372036597102792 cycles, -9223372036838092792 instret (after)
+256544518 cycles, 16335791 instret elapsed
+  ~15.704444 cycles-per-inst
+  ~12827.225900 cycles-per-iteration
+  ~816.789550 insts-per-iteration
+Running vlse-e64_m8_vlmax.out
+-9223372036853649868 cycles, -9223372036854427970 instret (before)
+-9223372036340848345 cycles, -9223372036837912128 instret (after)
+512801523 cycles, 16515842 instret elapsed
+  ~31.049069 cycles-per-inst
+  ~25640.076150 cycles-per-iteration
+  ~825.792100 insts-per-iteration
+Running vlse-e64_mf2_vlmax.out
+Running vlse-e64_mf4_vlmax.out
+Running vlse-e64_mf8_vlmax.out
+Running vlse-e8_m1_vlmax.out
+-9223372036853480590 cycles, -9223372036854393693 instret (before)
+-9223372036340203592 cycles, -9223372036837716284 instret (after)
+513276998 cycles, 16677409 instret elapsed
+  ~30.776783 cycles-per-inst
+  ~25663.849900 cycles-per-iteration
+  ~833.870450 insts-per-iteration
+Running vlse-e8_m2_vlmax.out
+-9223372036853598508 cycles, -9223372036854425237 instret (before)
+-9223372035827920817 cycles, -9223372036837440074 instret (after)
+1025677691 cycles, 16985163 instret elapsed
+  ~60.386685 cycles-per-inst
+  ~51283.884550 cycles-per-iteration
+  ~849.258150 insts-per-iteration
+Running vlse-e8_m4_vlmax.out
+-9223372036851936080 cycles, -9223372036854412582 instret (before)
+-9223372018559670682 cycles, -9223372036825683933 instret (after)
+18292265398 cycles, 28728649 instret elapsed
+  ~636.725570 cycles-per-inst
+  ~914613.269900 cycles-per-iteration
+  ~1436.432450 insts-per-iteration
+Running vlse-e8_m8_vlmax.out
+-9223372036849413226 cycles, -9223372036854408715 instret (before)
+-9223371953197980082 cycles, -9223372036771939988 instret (after)
+83651433144 cycles, 82468727 instret elapsed
+  ~1014.341268 cycles-per-inst
+  ~4182571.657200 cycles-per-iteration
+  ~4123.436350 insts-per-iteration
+Running vlse-e8_mf2_vlmax.out
+-9223372036853653858 cycles, -9223372036854425866 instret (before)
+-9223372036597118403 cycles, -9223372036838089095 instret (after)
+256535455 cycles, 16336771 instret elapsed
+  ~15.702947 cycles-per-inst
+  ~12826.772750 cycles-per-iteration
+  ~816.838550 insts-per-iteration
+Running vlse-e8_mf4_vlmax.out
+-9223372036853694329 cycles, -9223372036854428352 instret (before)
+-9223372036725188272 cycles, -9223372036838154573 instret (after)
+128506057 cycles, 16273779 instret elapsed
+  ~7.896510 cycles-per-inst
+  ~6425.302850 cycles-per-iteration
+  ~813.688950 insts-per-iteration
+Running vlse-e8_mf8_vlmax.out
+-9223372036853651040 cycles, -9223372036854428253 instret (before)
+-9223372036789340473 cycles, -9223372036838222080 instret (after)
+64310567 cycles, 16206173 instret elapsed
+  ~3.968276 cycles-per-inst
+  ~3215.528350 cycles-per-iteration
+  ~810.308650 insts-per-iteration

--- a/campaigns/vlse_LMUL_x_SEW_throughput_stride160/raw4.out
+++ b/campaigns/vlse_LMUL_x_SEW_throughput_stride160/raw4.out
@@ -1,0 +1,160 @@
+Running vlse-e16_m1_vlmax.out
+-9223372036853667181 cycles, -9223372036854428540 instret (before)
+-9223372036597018885 cycles, -9223372036838035233 instret (after)
+256648296 cycles, 16393307 instret elapsed
+  ~15.655676 cycles-per-inst
+  ~12832.414800 cycles-per-iteration
+  ~819.665350 insts-per-iteration
+Running vlse-e16_m2_vlmax.out
+-9223372036853642555 cycles, -9223372036854428080 instret (before)
+-9223372036340700783 cycles, -9223372036837911532 instret (after)
+512941772 cycles, 16516548 instret elapsed
+  ~31.056234 cycles-per-inst
+  ~25647.088600 cycles-per-iteration
+  ~825.827400 insts-per-iteration
+Running vlse-e16_m4_vlmax.out
+-9223372036853634116 cycles, -9223372036854425840 instret (before)
+-9223372035827656127 cycles, -9223372036837310771 instret (after)
+1025977989 cycles, 17115069 instret elapsed
+  ~59.945887 cycles-per-inst
+  ~51298.899450 cycles-per-iteration
+  ~855.753450 insts-per-iteration
+Running vlse-e16_m8_vlmax.out
+-9223372036850698563 cycles, -9223372036854423153 instret (before)
+-9223372014514566352 cycles, -9223372036823921510 instret (after)
+22336132211 cycles, 30501643 instret elapsed
+  ~732.292756 cycles-per-inst
+  ~1116806.610550 cycles-per-iteration
+  ~1525.082150 insts-per-iteration
+Running vlse-e16_mf2_vlmax.out
+-9223372036853616177 cycles, -9223372036854422231 instret (before)
+-9223372036725260409 cycles, -9223372036838176154 instret (after)
+128355768 cycles, 16246077 instret elapsed
+  ~7.900724 cycles-per-inst
+  ~6417.788400 cycles-per-iteration
+  ~812.303850 insts-per-iteration
+Running vlse-e16_mf4_vlmax.out
+-9223372036853674821 cycles, -9223372036854428011 instret (before)
+-9223372036789270805 cycles, -9223372036838207213 instret (after)
+64404016 cycles, 16220798 instret elapsed
+  ~3.970459 cycles-per-inst
+  ~3220.200800 cycles-per-iteration
+  ~811.039900 insts-per-iteration
+Running vlse-e16_mf8_vlmax.out
+Running vlse-e32_m1_vlmax.out
+-9223372036853646424 cycles, -9223372036854428120 instret (before)
+-9223372036725084150 cycles, -9223372036838148832 instret (after)
+128562274 cycles, 16279288 instret elapsed
+  ~7.897291 cycles-per-inst
+  ~6428.113700 cycles-per-iteration
+  ~813.964400 insts-per-iteration
+Running vlse-e32_m2_vlmax.out
+-9223372036853646378 cycles, -9223372036854429101 instret (before)
+-9223372036597121436 cycles, -9223372036838091472 instret (after)
+256524942 cycles, 16337629 instret elapsed
+  ~15.701479 cycles-per-inst
+  ~12826.247100 cycles-per-iteration
+  ~816.881450 insts-per-iteration
+Running vlse-e32_m4_vlmax.out
+-9223372036853498117 cycles, -9223372036854405074 instret (before)
+-9223372036340652288 cycles, -9223372036837883401 instret (after)
+512845829 cycles, 16521673 instret elapsed
+  ~31.040793 cycles-per-inst
+  ~25642.291450 cycles-per-iteration
+  ~826.083650 insts-per-iteration
+Running vlse-e32_m8_vlmax.out
+-9223372036853603492 cycles, -9223372036854424667 instret (before)
+-9223372035828100761 cycles, -9223372036837515123 instret (after)
+1025502731 cycles, 16909544 instret elapsed
+  ~60.646386 cycles-per-inst
+  ~51275.136550 cycles-per-iteration
+  ~845.477200 insts-per-iteration
+Running vlse-e32_mf2_vlmax.out
+-9223372036853647341 cycles, -9223372036854428110 instret (before)
+-9223372036789263134 cycles, -9223372036838206714 instret (after)
+64384207 cycles, 16221396 instret elapsed
+  ~3.969092 cycles-per-inst
+  ~3219.210350 cycles-per-iteration
+  ~811.069800 insts-per-iteration
+Running vlse-e32_mf4_vlmax.out
+Running vlse-e32_mf8_vlmax.out
+Running vlse-e64_m1_vlmax.out
+-9223372036853667076 cycles, -9223372036854428312 instret (before)
+-9223372036789093310 cycles, -9223372036838164887 instret (after)
+64573766 cycles, 16263425 instret elapsed
+  ~3.970490 cycles-per-inst
+  ~3228.688300 cycles-per-iteration
+  ~813.171250 insts-per-iteration
+Running vlse-e64_m2_vlmax.out
+-9223372036853644274 cycles, -9223372036854428959 instret (before)
+-9223372036725032441 cycles, -9223372036838129917 instret (after)
+128611833 cycles, 16299042 instret elapsed
+  ~7.890760 cycles-per-inst
+  ~6430.591650 cycles-per-iteration
+  ~814.952100 insts-per-iteration
+Running vlse-e64_m4_vlmax.out
+-9223372036853685124 cycles, -9223372036854428509 instret (before)
+-9223372036597067278 cycles, -9223372036838074219 instret (after)
+256617846 cycles, 16354290 instret elapsed
+  ~15.691164 cycles-per-inst
+  ~12830.892300 cycles-per-iteration
+  ~817.714500 insts-per-iteration
+Running vlse-e64_m8_vlmax.out
+-9223372036853625654 cycles, -9223372036854427502 instret (before)
+-9223372036340412165 cycles, -9223372036837791634 instret (after)
+513213489 cycles, 16635868 instret elapsed
+  ~30.849817 cycles-per-inst
+  ~25660.674450 cycles-per-iteration
+  ~831.793400 insts-per-iteration
+Running vlse-e64_mf2_vlmax.out
+Running vlse-e64_mf4_vlmax.out
+Running vlse-e64_mf8_vlmax.out
+Running vlse-e8_m1_vlmax.out
+-9223372036853674458 cycles, -9223372036854427414 instret (before)
+-9223372036340146400 cycles, -9223372036837635398 instret (after)
+513528058 cycles, 16792016 instret elapsed
+  ~30.581680 cycles-per-inst
+  ~25676.402900 cycles-per-iteration
+  ~839.600800 insts-per-iteration
+Running vlse-e8_m2_vlmax.out
+-9223372036853581390 cycles, -9223372036854425159 instret (before)
+-9223372035828137553 cycles, -9223372036837573754 instret (after)
+1025443837 cycles, 16851405 instret elapsed
+  ~60.852127 cycles-per-inst
+  ~51272.191850 cycles-per-iteration
+  ~842.570250 insts-per-iteration
+Running vlse-e8_m4_vlmax.out
+-9223372036851825340 cycles, -9223372036854421883 instret (before)
+-9223372016356514494 cycles, -9223372036821986404 instret (after)
+20495310846 cycles, 32435479 instret elapsed
+  ~631.879395 cycles-per-inst
+  ~1024765.542300 cycles-per-iteration
+  ~1621.773950 insts-per-iteration
+Running vlse-e8_m8_vlmax.out
+-9223372036847828082 cycles, -9223372036854407105 instret (before)
+-9223371952632107722 cycles, -9223372036782306940 instret (after)
+84215720360 cycles, 72100165 instret elapsed
+  ~1168.037831 cycles-per-inst
+  ~4210786.018000 cycles-per-iteration
+  ~3605.008250 insts-per-iteration
+Running vlse-e8_mf2_vlmax.out
+-9223372036853695678 cycles, -9223372036854429129 instret (before)
+-9223372036596971677 cycles, -9223372036838022532 instret (after)
+256724001 cycles, 16406597 instret elapsed
+  ~15.647608 cycles-per-inst
+  ~12836.200050 cycles-per-iteration
+  ~820.329850 insts-per-iteration
+Running vlse-e8_mf4_vlmax.out
+-9223372036853675959 cycles, -9223372036854429287 instret (before)
+-9223372036725121419 cycles, -9223372036838164399 instret (after)
+128554540 cycles, 16264888 instret elapsed
+  ~7.903807 cycles-per-inst
+  ~6427.727000 cycles-per-iteration
+  ~813.244400 insts-per-iteration
+Running vlse-e8_mf8_vlmax.out
+-9223372036853686862 cycles, -9223372036854429252 instret (before)
+-9223372036789295795 cycles, -9223372036838207043 instret (after)
+64391067 cycles, 16222209 instret elapsed
+  ~3.969316 cycles-per-inst
+  ~3219.553350 cycles-per-iteration
+  ~811.110450 insts-per-iteration

--- a/campaigns/vlseg_LMUL_x_SEW_throughput/raw3.out
+++ b/campaigns/vlseg_LMUL_x_SEW_throughput/raw3.out
@@ -1,0 +1,712 @@
+Running vlseg2-e16_m1_vlmax.out
+-9223372036853607024 cycles, -9223372036854425628 instret (before)
+-9223372036613118545 cycles, -9223372036834088441 instret (after)
+240488479 cycles, 20337187 instret elapsed
+  ~11.825061 cycles-per-inst
+  ~12024.423950 cycles-per-iteration
+  ~1016.859350 insts-per-iteration
+Running vlseg2-e16_m2_vlmax.out
+-9223372036853637461 cycles, -9223372036854425702 instret (before)
+-9223372036372706320 cycles, -9223372036833848197 instret (after)
+480931141 cycles, 20577505 instret elapsed
+  ~23.371694 cycles-per-inst
+  ~24046.557050 cycles-per-iteration
+  ~1028.875250 insts-per-iteration
+Running vlseg2-e16_m4_vlmax.out
+-9223372036853614062 cycles, -9223372036854426621 instret (before)
+-9223372035892353110 cycles, -9223372036833605385 instret (after)
+961260952 cycles, 20821236 instret elapsed
+  ~46.167334 cycles-per-inst
+  ~48063.047600 cycles-per-iteration
+  ~1041.061800 insts-per-iteration
+Running vlseg2-e16_m8_vlmax.out
+Running vlseg2-e16_mf2_vlmax.out
+-9223372036851974665 cycles, -9223372036853614039 instret (before)
+-9223372036731705649 cycles, -9223372036833388708 instret (after)
+120269016 cycles, 20225331 instret elapsed
+  ~5.946455 cycles-per-inst
+  ~6013.450800 cycles-per-iteration
+  ~1011.266550 insts-per-iteration
+Running vlseg2-e16_mf4_vlmax.out
+-9223372036851919500 cycles, -9223372036853574732 instret (before)
+-9223372036751633821 cycles, -9223372036833348060 instret (after)
+100285679 cycles, 20226672 instret elapsed
+  ~4.958091 cycles-per-inst
+  ~5014.283950 cycles-per-iteration
+  ~1011.333600 insts-per-iteration
+Running vlseg2-e16_mf8_vlmax.out
+Running vlseg2-e32_m1_vlmax.out
+-9223372036852077247 cycles, -9223372036853676797 instret (before)
+-9223372036611490626 cycles, -9223372036833316112 instret (after)
+240586621 cycles, 20360685 instret elapsed
+  ~11.816234 cycles-per-inst
+  ~12029.331050 cycles-per-iteration
+  ~1018.034250 insts-per-iteration
+Running vlseg2-e32_m2_vlmax.out
+-9223372036853552542 cycles, -9223372036854417882 instret (before)
+-9223372036371906403 cycles, -9223372036833698250 instret (after)
+481646139 cycles, 20719632 instret elapsed
+  ~23.245883 cycles-per-inst
+  ~24082.306950 cycles-per-iteration
+  ~1035.981600 insts-per-iteration
+Running vlseg2-e32_m4_vlmax.out
+-9223372036851787514 cycles, -9223372036853555193 instret (before)
+-9223372035890422722 cycles, -9223372036832621195 instret (after)
+961364792 cycles, 20933998 instret elapsed
+  ~45.923612 cycles-per-inst
+  ~48068.239600 cycles-per-iteration
+  ~1046.699900 insts-per-iteration
+Running vlseg2-e32_m8_vlmax.out
+Running vlseg2-e32_mf2_vlmax.out
+-9223372036851895164 cycles, -9223372036853603789 instret (before)
+-9223372036731618476 cycles, -9223372036833376896 instret (after)
+120276688 cycles, 20226893 instret elapsed
+  ~5.946375 cycles-per-inst
+  ~6013.834400 cycles-per-iteration
+  ~1011.344650 insts-per-iteration
+Running vlseg2-e32_mf4_vlmax.out
+Running vlseg2-e32_mf8_vlmax.out
+Running vlseg2-e64_m1_vlmax.out
+-9223372036852008820 cycles, -9223372036853607260 instret (before)
+-9223372036611560410 cycles, -9223372036833287212 instret (after)
+240448410 cycles, 20320048 instret elapsed
+  ~11.833063 cycles-per-inst
+  ~12022.420500 cycles-per-iteration
+  ~1016.002400 insts-per-iteration
+Running vlseg2-e64_m2_vlmax.out
+-9223372036853664954 cycles, -9223372036854426646 instret (before)
+-9223372036372663794 cycles, -9223372036833824972 instret (after)
+481001160 cycles, 20601674 instret elapsed
+  ~23.347674 cycles-per-inst
+  ~24050.058000 cycles-per-iteration
+  ~1030.083700 insts-per-iteration
+Running vlseg2-e64_m4_vlmax.out
+-9223372036851871240 cycles, -9223372036853610989 instret (before)
+-9223372035890676567 cycles, -9223372036832820151 instret (after)
+961194673 cycles, 20790838 instret elapsed
+  ~46.231647 cycles-per-inst
+  ~48059.733650 cycles-per-iteration
+  ~1039.541900 insts-per-iteration
+Running vlseg2-e64_m8_vlmax.out
+Running vlseg2-e64_mf2_vlmax.out
+Running vlseg2-e64_mf4_vlmax.out
+Running vlseg2-e64_mf8_vlmax.out
+Running vlseg2-e8_m1_vlmax.out
+-9223372036853648710 cycles, -9223372036854426721 instret (before)
+-9223372036612933485 cycles, -9223372036834025276 instret (after)
+240715225 cycles, 20401445 instret elapsed
+  ~11.798930 cycles-per-inst
+  ~12035.761250 cycles-per-iteration
+  ~1020.072250 insts-per-iteration
+Running vlseg2-e8_m2_vlmax.out
+-9223372036853562495 cycles, -9223372036854418202 instret (before)
+-9223372036372018119 cycles, -9223372036833734418 instret (after)
+481544376 cycles, 20683784 instret elapsed
+  ~23.281251 cycles-per-inst
+  ~24077.218800 cycles-per-iteration
+  ~1034.189200 insts-per-iteration
+Running vlseg2-e8_m4_vlmax.out
+-9223372036851873047 cycles, -9223372036853577658 instret (before)
+-9223372035890163925 cycles, -9223372036832564740 instret (after)
+961709122 cycles, 21012918 instret elapsed
+  ~45.767519 cycles-per-inst
+  ~48085.456100 cycles-per-iteration
+  ~1050.645900 insts-per-iteration
+Running vlseg2-e8_m8_vlmax.out
+Running vlseg2-e8_mf2_vlmax.out
+-9223372036851884219 cycles, -9223372036853566150 instret (before)
+-9223372036731649017 cycles, -9223372036833342621 instret (after)
+120235202 cycles, 20223529 instret elapsed
+  ~5.945313 cycles-per-inst
+  ~6011.760100 cycles-per-iteration
+  ~1011.176450 insts-per-iteration
+Running vlseg2-e8_mf4_vlmax.out
+-9223372036851957885 cycles, -9223372036853609199 instret (before)
+-9223372036751722524 cycles, -9223372036833399567 instret (after)
+100235361 cycles, 20209632 instret elapsed
+  ~4.959782 cycles-per-inst
+  ~5011.768050 cycles-per-iteration
+  ~1010.481600 insts-per-iteration
+Running vlseg2-e8_mf8_vlmax.out
+-9223372036851987618 cycles, -9223372036853609889 instret (before)
+-9223372036751750501 cycles, -9223372036833400419 instret (after)
+100237117 cycles, 20209470 instret elapsed
+  ~4.959908 cycles-per-inst
+  ~5011.855850 cycles-per-iteration
+  ~1010.473500 insts-per-iteration
+Running vlseg3-e16_m1_vlmax.out
+-9223372036851869879 cycles, -9223372036853578969 instret (before)
+-9223372036451161534 cycles, -9223372036833131267 instret (after)
+400708345 cycles, 20447702 instret elapsed
+  ~19.596742 cycles-per-inst
+  ~20035.417250 cycles-per-iteration
+  ~1022.385100 insts-per-iteration
+Running vlseg3-e16_m2_vlmax.out
+-9223372036851852903 cycles, -9223372036853580120 instret (before)
+-9223372036049690862 cycles, -9223372036832520840 instret (after)
+802162041 cycles, 21059280 instret elapsed
+  ~38.090668 cycles-per-inst
+  ~40108.102050 cycles-per-iteration
+  ~1052.964000 insts-per-iteration
+Running vlseg3-e16_m4_vlmax.out
+Running vlseg3-e16_m8_vlmax.out
+Running vlseg3-e16_mf2_vlmax.out
+-9223372036851916243 cycles, -9223372036853606848 instret (before)
+-9223372036651442135 cycles, -9223372036833307270 instret (after)
+200474108 cycles, 20299578 instret elapsed
+  ~9.875777 cycles-per-inst
+  ~10023.705400 cycles-per-iteration
+  ~1014.978900 insts-per-iteration
+Running vlseg3-e16_mf4_vlmax.out
+-9223372036851867517 cycles, -9223372036853569890 instret (before)
+-9223372036691432236 cycles, -9223372036833267497 instret (after)
+160435281 cycles, 20302393 instret elapsed
+  ~7.902284 cycles-per-inst
+  ~8021.764050 cycles-per-iteration
+  ~1015.119650 insts-per-iteration
+Running vlseg3-e16_mf8_vlmax.out
+Running vlseg3-e32_m1_vlmax.out
+-9223372036851927531 cycles, -9223372036853572852 instret (before)
+-9223372036450486379 cycles, -9223372036832974003 instret (after)
+401441152 cycles, 20598849 instret elapsed
+  ~19.488523 cycles-per-inst
+  ~20072.057600 cycles-per-iteration
+  ~1029.942450 insts-per-iteration
+Running vlseg3-e32_m2_vlmax.out
+-9223372036851891107 cycles, -9223372036853601524 instret (before)
+-9223372036050815684 cycles, -9223372036832901775 instret (after)
+801075423 cycles, 20699749 instret elapsed
+  ~38.699765 cycles-per-inst
+  ~40053.771150 cycles-per-iteration
+  ~1034.987450 insts-per-iteration
+Running vlseg3-e32_m4_vlmax.out
+Running vlseg3-e32_m8_vlmax.out
+Running vlseg3-e32_mf2_vlmax.out
+-9223372036851955469 cycles, -9223372036853571434 instret (before)
+-9223372036651433816 cycles, -9223372036833255414 instret (after)
+200521653 cycles, 20316020 instret elapsed
+  ~9.870125 cycles-per-inst
+  ~10026.082650 cycles-per-iteration
+  ~1015.801000 insts-per-iteration
+Running vlseg3-e32_mf4_vlmax.out
+Running vlseg3-e32_mf8_vlmax.out
+Running vlseg3-e64_m1_vlmax.out
+-9223372036852000425 cycles, -9223372036853572665 instret (before)
+-9223372036490946024 cycles, -9223372036833072492 instret (after)
+361054401 cycles, 20500173 instret elapsed
+  ~17.612261 cycles-per-inst
+  ~18052.720050 cycles-per-iteration
+  ~1025.008650 insts-per-iteration
+Running vlseg3-e64_m2_vlmax.out
+-9223372036851887153 cycles, -9223372036853577113 instret (before)
+-9223372036130215863 cycles, -9223372036832555760 instret (after)
+721671290 cycles, 21021353 instret elapsed
+  ~34.330392 cycles-per-inst
+  ~36083.564500 cycles-per-iteration
+  ~1051.067650 insts-per-iteration
+Running vlseg3-e64_m4_vlmax.out
+Running vlseg3-e64_m8_vlmax.out
+Running vlseg3-e64_mf2_vlmax.out
+Running vlseg3-e64_mf4_vlmax.out
+Running vlseg3-e64_mf8_vlmax.out
+Running vlseg3-e8_m1_vlmax.out
+-9223372036851868219 cycles, -9223372036853638007 instret (before)
+-9223372036451143922 cycles, -9223372036833185982 instret (after)
+400724297 cycles, 20452025 instret elapsed
+  ~19.593380 cycles-per-inst
+  ~20036.214850 cycles-per-iteration
+  ~1022.601250 insts-per-iteration
+Running vlseg3-e8_m2_vlmax.out
+-9223372036851970173 cycles, -9223372036853665113 instret (before)
+-9223372036051021560 cycles, -9223372036832974517 instret (after)
+800948613 cycles, 20690596 instret elapsed
+  ~38.710756 cycles-per-inst
+  ~40047.430650 cycles-per-iteration
+  ~1034.529800 insts-per-iteration
+Running vlseg3-e8_m4_vlmax.out
+Running vlseg3-e8_m8_vlmax.out
+Running vlseg3-e8_mf2_vlmax.out
+-9223372036851959159 cycles, -9223372036853578424 instret (before)
+-9223372036651475280 cycles, -9223372036833259792 instret (after)
+200483879 cycles, 20318632 instret elapsed
+  ~9.866997 cycles-per-inst
+  ~10024.193950 cycles-per-iteration
+  ~1015.931600 insts-per-iteration
+Running vlseg3-e8_mf4_vlmax.out
+-9223372036851949069 cycles, -9223372036853568938 instret (before)
+-9223372036691498162 cycles, -9223372036833283388 instret (after)
+160450907 cycles, 20285550 instret elapsed
+  ~7.909616 cycles-per-inst
+  ~8022.545350 cycles-per-iteration
+  ~1014.277500 insts-per-iteration
+Running vlseg3-e8_mf8_vlmax.out
+-9223372036851906839 cycles, -9223372036853573312 instret (before)
+-9223372036711256420 cycles, -9223372036833279948 instret (after)
+140650419 cycles, 20293364 instret elapsed
+  ~6.930858 cycles-per-inst
+  ~7032.520950 cycles-per-iteration
+  ~1014.668200 insts-per-iteration
+Running vlseg4-e16_m1_vlmax.out
+-9223372036851985011 cycles, -9223372036853665424 instret (before)
+-9223372036371249686 cycles, -9223372036833171257 instret (after)
+480735325 cycles, 20494167 instret elapsed
+  ~23.457178 cycles-per-inst
+  ~24036.766250 cycles-per-iteration
+  ~1024.708350 insts-per-iteration
+Running vlseg4-e16_m2_vlmax.out
+-9223372036851854499 cycles, -9223372036853575041 instret (before)
+-9223372035889895163 cycles, -9223372036832587899 instret (after)
+961959336 cycles, 20987142 instret elapsed
+  ~45.835652 cycles-per-inst
+  ~48097.966800 cycles-per-iteration
+  ~1049.357100 insts-per-iteration
+Running vlseg4-e16_m4_vlmax.out
+Running vlseg4-e16_m8_vlmax.out
+Running vlseg4-e16_mf2_vlmax.out
+-9223372036851790511 cycles, -9223372036853554893 instret (before)
+-9223372036611108128 cycles, -9223372036833182899 instret (after)
+240682383 cycles, 20371994 instret elapsed
+  ~11.814375 cycles-per-inst
+  ~12034.119150 cycles-per-iteration
+  ~1018.599700 insts-per-iteration
+Running vlseg4-e16_mf4_vlmax.out
+-9223372036851847169 cycles, -9223372036853570011 instret (before)
+-9223372036651228746 cycles, -9223372036833177981 instret (after)
+200618423 cycles, 20392030 instret elapsed
+  ~9.838080 cycles-per-inst
+  ~10030.921150 cycles-per-iteration
+  ~1019.601500 insts-per-iteration
+Running vlseg4-e16_mf8_vlmax.out
+Running vlseg4-e32_m1_vlmax.out
+-9223372036851857696 cycles, -9223372036853572045 instret (before)
+-9223372036371262542 cycles, -9223372036833110129 instret (after)
+480595154 cycles, 20461916 instret elapsed
+  ~23.487300 cycles-per-inst
+  ~24029.757700 cycles-per-iteration
+  ~1023.095800 insts-per-iteration
+Running vlseg4-e32_m2_vlmax.out
+-9223372036851845714 cycles, -9223372036853578385 instret (before)
+-9223372035890049532 cycles, -9223372036832600304 instret (after)
+961796182 cycles, 20978081 instret elapsed
+  ~45.847672 cycles-per-inst
+  ~48089.809100 cycles-per-iteration
+  ~1048.904050 insts-per-iteration
+Running vlseg4-e32_m4_vlmax.out
+Running vlseg4-e32_m8_vlmax.out
+Running vlseg4-e32_mf2_vlmax.out
+-9223372036852031988 cycles, -9223372036853671737 instret (before)
+-9223372036611442991 cycles, -9223372036833317871 instret (after)
+240588997 cycles, 20353866 instret elapsed
+  ~11.820310 cycles-per-inst
+  ~12029.449850 cycles-per-iteration
+  ~1017.693300 insts-per-iteration
+Running vlseg4-e32_mf4_vlmax.out
+Running vlseg4-e32_mf8_vlmax.out
+Running vlseg4-e64_m1_vlmax.out
+-9223372036851924463 cycles, -9223372036853577399 instret (before)
+-9223372036371136772 cycles, -9223372036833077326 instret (after)
+480787691 cycles, 20500073 instret elapsed
+  ~23.452975 cycles-per-inst
+  ~24039.384550 cycles-per-iteration
+  ~1025.003650 insts-per-iteration
+Running vlseg4-e64_m2_vlmax.out
+-9223372036851869444 cycles, -9223372036853577163 instret (before)
+-9223372035890062237 cycles, -9223372036832619943 instret (after)
+961807207 cycles, 20957220 instret elapsed
+  ~45.893835 cycles-per-inst
+  ~48090.360350 cycles-per-iteration
+  ~1047.861000 insts-per-iteration
+Running vlseg4-e64_m4_vlmax.out
+Running vlseg4-e64_m8_vlmax.out
+Running vlseg4-e64_mf2_vlmax.out
+Running vlseg4-e64_mf4_vlmax.out
+Running vlseg4-e64_mf8_vlmax.out
+Running vlseg4-e8_m1_vlmax.out
+-9223372036851893209 cycles, -9223372036853580385 instret (before)
+-9223372036370900587 cycles, -9223372036833028128 instret (after)
+480992622 cycles, 20552257 instret elapsed
+  ~23.403397 cycles-per-inst
+  ~24049.631100 cycles-per-iteration
+  ~1027.612850 insts-per-iteration
+Running vlseg4-e8_m2_vlmax.out
+-9223372036851871423 cycles, -9223372036853575769 instret (before)
+-9223372035890355647 cycles, -9223372036832576404 instret (after)
+961515776 cycles, 20999365 instret elapsed
+  ~45.787850 cycles-per-inst
+  ~48075.788800 cycles-per-iteration
+  ~1049.968250 insts-per-iteration
+Running vlseg4-e8_m4_vlmax.out
+Running vlseg4-e8_m8_vlmax.out
+Running vlseg4-e8_mf2_vlmax.out
+-9223372036851874611 cycles, -9223372036853572977 instret (before)
+-9223372036611410760 cycles, -9223372036833235021 instret (after)
+240463851 cycles, 20337956 instret elapsed
+  ~11.823403 cycles-per-inst
+  ~12023.192550 cycles-per-iteration
+  ~1016.897800 insts-per-iteration
+Running vlseg4-e8_mf4_vlmax.out
+-9223372036851906899 cycles, -9223372036853569275 instret (before)
+-9223372036651589517 cycles, -9223372036833295470 instret (after)
+200317382 cycles, 20273805 instret elapsed
+  ~9.880601 cycles-per-inst
+  ~10015.869100 cycles-per-iteration
+  ~1013.690250 insts-per-iteration
+Running vlseg4-e8_mf8_vlmax.out
+-9223372036851879829 cycles, -9223372036853578579 instret (before)
+-9223372036671557991 cycles, -9223372036833315686 instret (after)
+180321838 cycles, 20262893 instret elapsed
+  ~8.899116 cycles-per-inst
+  ~9016.091900 cycles-per-iteration
+  ~1013.144650 insts-per-iteration
+Running vlseg5-e16_m1_vlmax.out
+-9223372036851805437 cycles, -9223372036853570365 instret (before)
+-9223372035249583286 cycles, -9223372036832133242 instret (after)
+1602222151 cycles, 21437123 instret elapsed
+  ~74.740540 cycles-per-inst
+  ~80111.107550 cycles-per-iteration
+  ~1071.856150 insts-per-iteration
+Running vlseg5-e16_m2_vlmax.out
+Running vlseg5-e16_m4_vlmax.out
+Running vlseg5-e16_m8_vlmax.out
+Running vlseg5-e16_mf2_vlmax.out
+-9223372036852013405 cycles, -9223372036853672816 instret (before)
+-9223372036050790223 cycles, -9223372036832954671 instret (after)
+801223182 cycles, 20718145 instret elapsed
+  ~38.672535 cycles-per-inst
+  ~40061.159100 cycles-per-iteration
+  ~1035.907250 insts-per-iteration
+Running vlseg5-e16_mf4_vlmax.out
+-9223372036851852813 cycles, -9223372036853563740 instret (before)
+-9223372036451239125 cycles, -9223372036833153927 instret (after)
+400613688 cycles, 20409813 instret elapsed
+  ~19.628484 cycles-per-inst
+  ~20030.684400 cycles-per-iteration
+  ~1020.490650 insts-per-iteration
+Running vlseg5-e16_mf8_vlmax.out
+Running vlseg5-e32_m1_vlmax.out
+-9223372036851955905 cycles, -9223372036853575515 instret (before)
+-9223372036050606149 cycles, -9223372036832802774 instret (after)
+801349756 cycles, 20772741 instret elapsed
+  ~38.576987 cycles-per-inst
+  ~40067.487800 cycles-per-iteration
+  ~1038.637050 insts-per-iteration
+Running vlseg5-e32_m2_vlmax.out
+Running vlseg5-e32_m4_vlmax.out
+Running vlseg5-e32_m8_vlmax.out
+Running vlseg5-e32_mf2_vlmax.out
+-9223372036851833181 cycles, -9223372036853571593 instret (before)
+-9223372036451039872 cycles, -9223372036833134157 instret (after)
+400793309 cycles, 20437436 instret elapsed
+  ~19.610743 cycles-per-inst
+  ~20039.665450 cycles-per-iteration
+  ~1021.871800 insts-per-iteration
+Running vlseg5-e32_mf4_vlmax.out
+Running vlseg5-e32_mf8_vlmax.out
+Running vlseg5-e64_m1_vlmax.out
+-9223372036851921289 cycles, -9223372036853569747 instret (before)
+-9223372036450890669 cycles, -9223372036833075169 instret (after)
+401030620 cycles, 20494578 instret elapsed
+  ~19.567645 cycles-per-inst
+  ~20051.531000 cycles-per-iteration
+  ~1024.728900 insts-per-iteration
+Running vlseg5-e64_m2_vlmax.out
+Running vlseg5-e64_m4_vlmax.out
+Running vlseg5-e64_m8_vlmax.out
+Running vlseg5-e64_mf2_vlmax.out
+Running vlseg5-e64_mf4_vlmax.out
+Running vlseg5-e64_mf8_vlmax.out
+Running vlseg5-e8_m1_vlmax.out
+-9223372036851657258 cycles, -9223372036853550184 instret (before)
+-9223372033647859736 cycles, -9223372036831167744 instret (after)
+3203797522 cycles, 22382440 instret elapsed
+  ~143.138886 cycles-per-inst
+  ~160189.876100 cycles-per-iteration
+  ~1119.122000 insts-per-iteration
+Running vlseg5-e8_m2_vlmax.out
+Running vlseg5-e8_m4_vlmax.out
+Running vlseg5-e8_m8_vlmax.out
+Running vlseg5-e8_mf2_vlmax.out
+-9223372036851908949 cycles, -9223372036853580289 instret (before)
+-9223372035249933634 cycles, -9223372036832314704 instret (after)
+1601975315 cycles, 21265585 instret elapsed
+  ~75.331824 cycles-per-inst
+  ~80098.765750 cycles-per-iteration
+  ~1063.279250 insts-per-iteration
+Running vlseg5-e8_mf4_vlmax.out
+-9223372036851868137 cycles, -9223372036853574944 instret (before)
+-9223372036050507704 cycles, -9223372036832784922 instret (after)
+801360433 cycles, 20790022 instret elapsed
+  ~38.545435 cycles-per-inst
+  ~40068.021650 cycles-per-iteration
+  ~1039.501100 insts-per-iteration
+Running vlseg5-e8_mf8_vlmax.out
+-9223372036851908965 cycles, -9223372036853567813 instret (before)
+-9223372036451238578 cycles, -9223372036833141893 instret (after)
+400670387 cycles, 20425920 instret elapsed
+  ~19.615782 cycles-per-inst
+  ~20033.519350 cycles-per-iteration
+  ~1021.296000 insts-per-iteration
+Running vlseg6-e16_m1_vlmax.out
+-9223372036851749027 cycles, -9223372036853563047 instret (before)
+-9223372034928713147 cycles, -9223372036831835670 instret (after)
+1923035880 cycles, 21727377 instret elapsed
+  ~88.507503 cycles-per-inst
+  ~96151.794000 cycles-per-iteration
+  ~1086.368850 insts-per-iteration
+Running vlseg6-e16_m2_vlmax.out
+Running vlseg6-e16_m4_vlmax.out
+Running vlseg6-e16_m8_vlmax.out
+Running vlseg6-e16_mf2_vlmax.out
+-9223372036851938389 cycles, -9223372036853575772 instret (before)
+-9223372035890329133 cycles, -9223372036832656365 instret (after)
+961609256 cycles, 20919407 instret elapsed
+  ~45.967329 cycles-per-inst
+  ~48080.462800 cycles-per-iteration
+  ~1045.970350 insts-per-iteration
+Running vlseg6-e16_mf4_vlmax.out
+-9223372036851940641 cycles, -9223372036853575535 instret (before)
+-9223372036371108511 cycles, -9223372036833075336 instret (after)
+480832130 cycles, 20500199 instret elapsed
+  ~23.454998 cycles-per-inst
+  ~24041.606500 cycles-per-iteration
+  ~1025.009950 insts-per-iteration
+Running vlseg6-e16_mf8_vlmax.out
+Running vlseg6-e32_m1_vlmax.out
+-9223372036851954315 cycles, -9223372036853575432 instret (before)
+-9223372035890619090 cycles, -9223372036832757821 instret (after)
+961335225 cycles, 20817611 instret elapsed
+  ~46.178941 cycles-per-inst
+  ~48066.761250 cycles-per-iteration
+  ~1040.880550 insts-per-iteration
+Running vlseg6-e32_m2_vlmax.out
+Running vlseg6-e32_m4_vlmax.out
+Running vlseg6-e32_m8_vlmax.out
+Running vlseg6-e32_mf2_vlmax.out
+-9223372036851988332 cycles, -9223372036853669765 instret (before)
+-9223372036370988425 cycles, -9223372036833109475 instret (after)
+480999907 cycles, 20560290 instret elapsed
+  ~23.394607 cycles-per-inst
+  ~24049.995350 cycles-per-iteration
+  ~1028.014500 insts-per-iteration
+Running vlseg6-e32_mf4_vlmax.out
+Running vlseg6-e32_mf8_vlmax.out
+Running vlseg6-e64_m1_vlmax.out
+-9223372036851930417 cycles, -9223372036853576731 instret (before)
+-9223372036370655545 cycles, -9223372036832876184 instret (after)
+481274872 cycles, 20700547 instret elapsed
+  ~23.249379 cycles-per-inst
+  ~24063.743600 cycles-per-iteration
+  ~1035.027350 insts-per-iteration
+Running vlseg6-e64_m2_vlmax.out
+Running vlseg6-e64_m4_vlmax.out
+Running vlseg6-e64_m8_vlmax.out
+Running vlseg6-e64_mf2_vlmax.out
+Running vlseg6-e64_mf4_vlmax.out
+Running vlseg6-e64_mf8_vlmax.out
+Running vlseg6-e8_m1_vlmax.out
+-9223372036851715309 cycles, -9223372036853566389 instret (before)
+-9223372033007150632 cycles, -9223372036830433449 instret (after)
+3844564677 cycles, 23132940 instret elapsed
+  ~166.194382 cycles-per-inst
+  ~192228.233850 cycles-per-iteration
+  ~1156.647000 insts-per-iteration
+Running vlseg6-e8_m2_vlmax.out
+Running vlseg6-e8_m4_vlmax.out
+Running vlseg6-e8_m8_vlmax.out
+Running vlseg6-e8_mf2_vlmax.out
+-9223372036851874238 cycles, -9223372036853655951 instret (before)
+-9223372034929490750 cycles, -9223372036832160939 instret (after)
+1922383488 cycles, 21495012 instret elapsed
+  ~89.433934 cycles-per-inst
+  ~96119.174400 cycles-per-iteration
+  ~1074.750600 insts-per-iteration
+Running vlseg6-e8_mf4_vlmax.out
+-9223372036851821605 cycles, -9223372036853570721 instret (before)
+-9223372035889703230 cycles, -9223372036832409566 instret (after)
+962118375 cycles, 21161155 instret elapsed
+  ~45.466251 cycles-per-inst
+  ~48105.918750 cycles-per-iteration
+  ~1058.057750 insts-per-iteration
+Running vlseg6-e8_mf8_vlmax.out
+-9223372036851961990 cycles, -9223372036853576586 instret (before)
+-9223372036370980945 cycles, -9223372036833043570 instret (after)
+480981045 cycles, 20533016 instret elapsed
+  ~23.424764 cycles-per-inst
+  ~24049.052250 cycles-per-iteration
+  ~1026.650800 insts-per-iteration
+Running vlseg7-e16_m1_vlmax.out
+-9223372036851754483 cycles, -9223372036853572631 instret (before)
+-9223372034608133985 cycles, -9223372036831513239 instret (after)
+2243620498 cycles, 22059392 instret elapsed
+  ~101.708175 cycles-per-inst
+  ~112181.024900 cycles-per-iteration
+  ~1102.969600 insts-per-iteration
+Running vlseg7-e16_m2_vlmax.out
+Running vlseg7-e16_m4_vlmax.out
+Running vlseg7-e16_m8_vlmax.out
+Running vlseg7-e16_mf2_vlmax.out
+-9223372036851907393 cycles, -9223372036853566863 instret (before)
+-9223372035729493052 cycles, -9223372036832368471 instret (after)
+1122414341 cycles, 21198392 instret elapsed
+  ~52.948089 cycles-per-inst
+  ~56120.717050 cycles-per-iteration
+  ~1059.919600 insts-per-iteration
+Running vlseg7-e16_mf4_vlmax.out
+-9223372036851820523 cycles, -9223372036853570770 instret (before)
+-9223372036290920199 cycles, -9223372036832983272 instret (after)
+560900324 cycles, 20587498 instret elapsed
+  ~27.244706 cycles-per-inst
+  ~28045.016200 cycles-per-iteration
+  ~1029.374900 insts-per-iteration
+Running vlseg7-e16_mf8_vlmax.out
+Running vlseg7-e32_m1_vlmax.out
+-9223372036851941689 cycles, -9223372036853576404 instret (before)
+-9223372035729817951 cycles, -9223372036832473215 instret (after)
+1122123738 cycles, 21103189 instret elapsed
+  ~53.173183 cycles-per-inst
+  ~56106.186900 cycles-per-iteration
+  ~1055.159450 insts-per-iteration
+Running vlseg7-e32_m2_vlmax.out
+Running vlseg7-e32_m4_vlmax.out
+Running vlseg7-e32_m8_vlmax.out
+Running vlseg7-e32_mf2_vlmax.out
+-9223372036851778167 cycles, -9223372036853569551 instret (before)
+-9223372036290392991 cycles, -9223372036832902028 instret (after)
+561385176 cycles, 20667523 instret elapsed
+  ~27.162673 cycles-per-inst
+  ~28069.258800 cycles-per-iteration
+  ~1033.376150 insts-per-iteration
+Running vlseg7-e32_mf4_vlmax.out
+Running vlseg7-e32_mf8_vlmax.out
+Running vlseg7-e64_m1_vlmax.out
+-9223372036852029103 cycles, -9223372036853669811 instret (before)
+-9223372036291037476 cycles, -9223372036833094374 instret (after)
+560991627 cycles, 20575437 instret elapsed
+  ~27.265114 cycles-per-inst
+  ~28049.581350 cycles-per-iteration
+  ~1028.771850 insts-per-iteration
+Running vlseg7-e64_m2_vlmax.out
+Running vlseg7-e64_m4_vlmax.out
+Running vlseg7-e64_m8_vlmax.out
+Running vlseg7-e64_mf2_vlmax.out
+Running vlseg7-e64_mf4_vlmax.out
+Running vlseg7-e64_mf8_vlmax.out
+Running vlseg7-e8_m1_vlmax.out
+-9223372036851619365 cycles, -9223372036853571897 instret (before)
+-9223372032365598823 cycles, -9223372036829825081 instret (after)
+4486020542 cycles, 23746816 instret elapsed
+  ~188.910401 cycles-per-inst
+  ~224301.027100 cycles-per-iteration
+  ~1187.340800 insts-per-iteration
+Running vlseg7-e8_m2_vlmax.out
+Running vlseg7-e8_m4_vlmax.out
+Running vlseg7-e8_m8_vlmax.out
+Running vlseg7-e8_mf2_vlmax.out
+-9223372036851859411 cycles, -9223372036853577056 instret (before)
+-9223372034608429299 cycles, -9223372036831604747 instret (after)
+2243430112 cycles, 21972309 instret elapsed
+  ~102.102611 cycles-per-inst
+  ~112171.505600 cycles-per-iteration
+  ~1098.615450 insts-per-iteration
+Running vlseg7-e8_mf4_vlmax.out
+-9223372036851836349 cycles, -9223372036853569578 instret (before)
+-9223372035730183830 cycles, -9223372036832545020 instret (after)
+1121652519 cycles, 21024558 instret elapsed
+  ~53.349636 cycles-per-inst
+  ~56082.625950 cycles-per-iteration
+  ~1051.227900 insts-per-iteration
+Running vlseg7-e8_mf8_vlmax.out
+-9223372036851965241 cycles, -9223372036853576401 instret (before)
+-9223372036290817662 cycles, -9223372036832951481 instret (after)
+561147579 cycles, 20624920 instret elapsed
+  ~27.207261 cycles-per-inst
+  ~28057.378950 cycles-per-iteration
+  ~1031.246000 insts-per-iteration
+Running vlseg8-e16_m1_vlmax.out
+-9223372036851785475 cycles, -9223372036853577243 instret (before)
+-9223372034288243238 cycles, -9223372036831395745 instret (after)
+2563542237 cycles, 22181498 instret elapsed
+  ~115.571195 cycles-per-inst
+  ~128177.111850 cycles-per-iteration
+  ~1109.074900 insts-per-iteration
+Running vlseg8-e16_m2_vlmax.out
+Running vlseg8-e16_m4_vlmax.out
+Running vlseg8-e16_m8_vlmax.out
+Running vlseg8-e16_mf2_vlmax.out
+-9223372036851806379 cycles, -9223372036853572247 instret (before)
+-9223372035569865386 cycles, -9223372036832444972 instret (after)
+1281940993 cycles, 21127275 instret elapsed
+  ~60.677063 cycles-per-inst
+  ~64097.049650 cycles-per-iteration
+  ~1056.363750 insts-per-iteration
+Running vlseg8-e16_mf4_vlmax.out
+-9223372036851874983 cycles, -9223372036853572379 instret (before)
+-9223372036210727349 cycles, -9223372036832893182 instret (after)
+641147634 cycles, 20679197 instret elapsed
+  ~31.004474 cycles-per-inst
+  ~32057.381700 cycles-per-iteration
+  ~1033.959850 insts-per-iteration
+Running vlseg8-e16_mf8_vlmax.out
+Running vlseg8-e32_m1_vlmax.out
+-9223372036851901373 cycles, -9223372036853576984 instret (before)
+-9223372035569913748 cycles, -9223372036832383025 instret (after)
+1281987625 cycles, 21193959 instret elapsed
+  ~60.488351 cycles-per-inst
+  ~64099.381250 cycles-per-iteration
+  ~1059.697950 insts-per-iteration
+Running vlseg8-e32_m2_vlmax.out
+Running vlseg8-e32_m4_vlmax.out
+Running vlseg8-e32_m8_vlmax.out
+Running vlseg8-e32_mf2_vlmax.out
+-9223372036851849447 cycles, -9223372036853553699 instret (before)
+-9223372036210522903 cycles, -9223372036832857411 instret (after)
+641326544 cycles, 20696288 instret elapsed
+  ~30.987515 cycles-per-inst
+  ~32066.327200 cycles-per-iteration
+  ~1034.814400 insts-per-iteration
+Running vlseg8-e32_mf4_vlmax.out
+Running vlseg8-e32_mf8_vlmax.out
+Running vlseg8-e64_m1_vlmax.out
+-9223372036851961201 cycles, -9223372036853577955 instret (before)
+-9223372036210691125 cycles, -9223372036832903899 instret (after)
+641270076 cycles, 20674056 instret elapsed
+  ~31.018107 cycles-per-inst
+  ~32063.503800 cycles-per-iteration
+  ~1033.702800 insts-per-iteration
+Running vlseg8-e64_m2_vlmax.out
+Running vlseg8-e64_m4_vlmax.out
+Running vlseg8-e64_m8_vlmax.out
+Running vlseg8-e64_mf2_vlmax.out
+Running vlseg8-e64_mf4_vlmax.out
+Running vlseg8-e64_mf8_vlmax.out
+Running vlseg8-e8_m1_vlmax.out
+-9223372036851664847 cycles, -9223372036853567245 instret (before)
+-9223372031723682878 cycles, -9223372036828910508 instret (after)
+5127981969 cycles, 24656737 instret elapsed
+  ~207.974882 cycles-per-inst
+  ~256399.098450 cycles-per-iteration
+  ~1232.836850 insts-per-iteration
+Running vlseg8-e8_m2_vlmax.out
+Running vlseg8-e8_m4_vlmax.out
+Running vlseg8-e8_m8_vlmax.out
+Running vlseg8-e8_mf2_vlmax.out
+-9223372036851810207 cycles, -9223372036853582078 instret (before)
+-9223372034288083510 cycles, -9223372036831263077 instret (after)
+2563726697 cycles, 22319001 instret elapsed
+  ~114.867448 cycles-per-inst
+  ~128186.334850 cycles-per-iteration
+  ~1115.950050 insts-per-iteration
+Running vlseg8-e8_mf4_vlmax.out
+-9223372036851789041 cycles, -9223372036853563727 instret (before)
+-9223372035569643654 cycles, -9223372036832355665 instret (after)
+1282145387 cycles, 21208062 instret elapsed
+  ~60.455566 cycles-per-inst
+  ~64107.269350 cycles-per-iteration
+  ~1060.403100 insts-per-iteration
+Running vlseg8-e8_mf8_vlmax.out
+-9223372036851870945 cycles, -9223372036853580164 instret (before)
+-9223372036210495763 cycles, -9223372036832871998 instret (after)
+641375182 cycles, 20708166 instret elapsed
+  ~30.972090 cycles-per-inst
+  ~32068.759100 cycles-per-iteration
+  ~1035.408300 insts-per-iteration

--- a/driver/driver.c
+++ b/driver/driver.c
@@ -9,10 +9,11 @@ void measure(char*);
 #define N 20000
 
 int main() {
+  char A[256*1024];
+  measure(A); // Warm up caches
   uint64_t cycles_begin = 0, instrs_begin = 0;
   read_counters(&cycles_begin, &instrs_begin);
   printf("%ld cycles, %ld instret (before)\n", cycles_begin, instrs_begin);
-  char A[256*1024];
   for (int i = 0; i < N; i++)
     measure(A);
 


### PR DESCRIPTION
This seems to remove the noise in some of the vlseg/vlse results, and I'm able to get two pretty consistent consecutive runs now for vlse_LMUL_x_SEW_throughput.

My guess is that because the measure function is so big it's mostly the instruction cache that was causing the variance beforehand.
